### PR TITLE
:hankey: Added default `right: inital` to select's popOver styles.

### DIFF
--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -143,6 +143,8 @@ class Select extends Component {
       (activeChild && activeChild.props && activeChild.props.text) || value || placeholder
     );
 
+    const popOverStyle = combineStyles({ minWidth: popOverWidth, right: 'initial' }, contentStyle);
+
     return (
       <section
         ref={container => (this.container = container)}
@@ -162,7 +164,7 @@ class Select extends Component {
           </div>
         </header>
         <PopOver
-          style={combineStyles({ minWidth: popOverWidth, right: 'initial' }, contentStyle)}
+          style={popOverStyle}
           open={open}
           popOverRef={popOver => (this.popOver = popOver)}
           position={position}

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -162,7 +162,7 @@ class Select extends Component {
           </div>
         </header>
         <PopOver
-          style={combineStyles({ minWidth: popOverWidth }, contentStyle)}
+          style={combineStyles({ minWidth: popOverWidth, right: 'initial' }, contentStyle)}
           open={open}
           popOverRef={popOver => (this.popOver = popOver)}
           position={position}


### PR DESCRIPTION
We should find a better fix for this. Fixes #530. #530 

_Nasty fix now for ie11_
_Reason is on first render position is not calculated yet_