### PR TITLE
added textAlign: 'left'

### DIFF
--- a/src/table-header-column/styles.js
+++ b/src/table-header-column/styles.js
@@ -3,6 +3,7 @@ export default {
     padding: '16px',
     color: 'inherit',
     fontWeight: 'inherit',
-    fontSize: 'inherit'
+    fontSize: 'inherit',
+    textAlign: 'left'
   }
 };


### PR DESCRIPTION
Added text-align : left; on the th's. This fixes the illusion that the table header and table body are not aligned.