### PR TITLE
Implemented 8dp grid to Avatar.

### DIFF
--- a/src/avatar/styles.js
+++ b/src/avatar/styles.js
@@ -12,8 +12,8 @@ export default {
     backgroundImage: 'url()'
   },
   status: {
-    width: '10px',
-    height: '10px',
+    width: '8px',
+    height: '8px',
     border: `1px solid ${colors.white}`,
     backgroundColor: colors.offline,
     borderRadius: '50%',


### PR DESCRIPTION
Not sure about this one... Because of the `1px` border the rendered div is 12x12 _(12/8 = 1.5)_. Having said this do we want the visual render to be within the grid or do we want the numbers in the styles to be, for instance `width: 8px || 10px` which render to `width: 10px || 12px`

- [x] discuss