### PR TITLE
[Input] Set name property to actually be the name property

### DIFF
--- a/src/input/component.jsx
+++ b/src/input/component.jsx
@@ -145,6 +145,7 @@ class Input extends Component {
         type={type}
         maxLength={maxLength}
         id={name}
+        name={name}
         placeholder={placeholder}
         disabled={disabled}
         {...custom}
@@ -163,6 +164,7 @@ class Input extends Component {
             maxLength={maxLength}
             rows={maxRows}
             id={name}
+            name={name}
             placeholder={placeholder}
             ref={(node) => { this.textarea = node; }}
             disabled={disabled}


### PR DESCRIPTION
The name property for the input elements was not being set to the name prop specified on the Anchor Input element. It is only passing the name property to the id prop on the input element

